### PR TITLE
fix: add `react` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "peerDependencies": {
     "jotai": ">=2.0.0",
+    "react": ">=19.0.0",
     "waku": ">=0.23.6"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/wakujs/waku/pull/1552#issuecomment-3101315698